### PR TITLE
fix: token regex digit 5-8 length

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	tokenService.init(storageManager);
 	var token: any = await storageManager.getValue('token');
 
-	const tokenRegex = /^[a-z]{2}[_]\d{8}[_].{32}/g;
+	const tokenRegex = /^[a-z]{2}[_]\d{5,8}[_].{32}/g;
 	var wrapper: ApiWrapper;
 	var statusChanger: StatusChanger;
 


### PR DESCRIPTION
I've updated the token's regular expression to match an 8-digit pattern. This change addresses issue #12 